### PR TITLE
fix: using all passed options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,7 +41,7 @@ export class ChromeWebstoreAPI {
       }
     }
 
-    this.options = options
+    this.options = { ...options }
   }
 
   get uploadEndpoint() {

--- a/index.ts
+++ b/index.ts
@@ -39,9 +39,9 @@ export class ChromeWebstoreAPI {
       if (!options[field]) {
         throw new Error(errorMap[field])
       }
-
-      this.options[field] = options[field]
     }
+
+    this.options = options
   }
 
   get uploadEndpoint() {


### PR DESCRIPTION
Didn't see anything in the README about how to properly format PRs, please let me know if there's anything you would like me to do to validate this change.

**Description**

When testing the Github action my extension is not in a publishable state and the action kept failing (I wanted to just upload and not publish). After investigation I realized it was because the `uploadOnly` option was not being assigned to `this.options` in the constructor.

This change will still check for required fields but use all passed constructor options. If you'd like it to be more specific to only allow defined options I'm happy to make that change as well.